### PR TITLE
Add DNS latency workload and measurement

### DIFF
--- a/docs/how-to-dns-latency.md
+++ b/docs/how-to-dns-latency.md
@@ -1,0 +1,35 @@
+# DNS latency troubleshooting with kube-burner
+
+This guide walks through running the `dns-latency` workload to measure DNS resolution latency on a Kubernetes cluster.
+
+## Prerequisites
+
+- Access to a Kubernetes cluster. The job works on clusters such as kind or OpenShift.
+- `kubectl` configured to talk to the cluster.
+- The `kube-burner` binary available in your `$PATH`.
+
+## Running on kind
+
+```bash
+kind create cluster
+```
+
+The workload can also target any existing cluster by ensuring `KUBECONFIG` points to it.
+
+## Launch the workload
+
+From the repository root run:
+
+```bash
+hack/dns-latency.sh
+```
+
+This script invokes kube-burner with the [dns-latency job](examples/workloads/dns-latency/dns-latency.yml) which
+spawns a `dnsperf` pod that repeatedly queries the cluster DNS service.
+
+## Results
+
+Metrics are written to the local `kube-burner/` directory. Files prefixed with `dnsLatencyMeasurement` contain
+average, minimum and maximum query latency extracted from the `dnsperf` run.
+
+These numbers can help identify slow DNS responses or network path issues.

--- a/examples/workloads/dns-latency/dns-latency.yml
+++ b/examples/workloads/dns-latency/dns-latency.yml
@@ -1,0 +1,24 @@
+---
+global:
+  gc: true
+  gcMetrics: false
+  measurements:
+    - name: dnsLatency
+metricsEndpoints:
+  - indexer:
+      metricsDirectory: kube-burner
+      type: local
+
+jobs:
+  - name: dns-latency
+    namespace: dns-latency
+    jobIterations: 1
+    podWait: true
+    waitWhenFinished: true
+    cleanup: true
+    objects:
+      - objectTemplate: templates/dnsperf-pod.yml
+        replicas: 1
+        inputVars:
+          dnsServer: kube-dns.kube-system.svc.cluster.local
+          duration: 10

--- a/examples/workloads/dns-latency/templates/dnsperf-pod.yml
+++ b/examples/workloads/dns-latency/templates/dnsperf-pod.yml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: dnsperf-{{ .Iteration }}
+  labels:
+    app: dnsperf
+    kube-burner-job: dns-latency
+spec:
+  restartPolicy: Never
+  containers:
+  - name: dnsperf
+    image: registry.k8s.io/e2e-test-images/dnsperf:1.0
+    command:
+      - /bin/sh
+      - -c
+      - |
+        dnsperf -s {{ .dnsServer }} -l {{ .duration }} -q 100

--- a/hack/dns-latency.sh
+++ b/hack/dns-latency.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+KUBEBURNER=${KUBEBURNER:-kube-burner}
+JOB_FILE=$(dirname "$0")/../examples/workloads/dns-latency/dns-latency.yml
+
+$KUBEBURNER init -c "$JOB_FILE" "$@"

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -5,12 +5,14 @@ nav:
 - Command line: cli/index.md
 - Reference: reference/configuration.md
 - Measurements: measurements/index.md
-- Observability & Alerting: 
+- Observability & Alerting:
   - observability/index.md
   - Overview: observability/index.md
   - Collecting metrics: observability/metrics.md
   - Indexing: observability/indexing.md
   - Alerting: observability/alerting.md
+- How-to:
+  - how-to-dns-latency.md
 - Contributing:
   - contributing/index.md
   - GitHub Workflows:

--- a/pkg/measurements/dns_latency.go
+++ b/pkg/measurements/dns_latency.go
@@ -1,0 +1,135 @@
+package measurements
+
+import (
+	"bufio"
+	"context"
+	"regexp"
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/kube-burner/kube-burner/pkg/config"
+	"github.com/kube-burner/kube-burner/pkg/measurements/metrics"
+	"github.com/kube-burner/kube-burner/pkg/measurements/types"
+	"github.com/kube-burner/kube-burner/pkg/util/fileutils"
+	log "github.com/sirupsen/logrus"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+)
+
+const (
+	dnsLatencyMeasurement          = "dnsLatencyMeasurement"
+	dnsLatencyQuantilesMeasurement = "dnsLatencyQuantilesMeasurement"
+)
+
+type dnsLatency struct {
+	BaseMeasurement
+}
+
+type dnsMetric struct {
+	Timestamp  time.Time `json:"timestamp"`
+	Avg        float64   `json:"avgLatency"`
+	Min        float64   `json:"minLatency"`
+	Max        float64   `json:"maxLatency"`
+	MetricName string    `json:"metricName"`
+	UUID       string    `json:"uuid"`
+	Namespace  string    `json:"namespace"`
+	Name       string    `json:"pod"`
+	JobName    string    `json:"jobName,omitempty"`
+	Metadata   any       `json:"metadata,omitempty"`
+}
+
+type dnsLatencyMeasurementFactory struct {
+	BaseMeasurementFactory
+}
+
+func newDnsLatencyMeasurementFactory(configSpec config.Spec, measurement types.Measurement, metadata map[string]any) (MeasurementFactory, error) {
+	return dnsLatencyMeasurementFactory{
+		BaseMeasurementFactory: NewBaseMeasurementFactory(configSpec, measurement, metadata),
+	}, nil
+}
+
+func (dlmf dnsLatencyMeasurementFactory) NewMeasurement(jobConfig *config.Job, clientSet kubernetes.Interface, restConfig *rest.Config, embedCfg *fileutils.EmbedConfiguration) Measurement {
+	return &dnsLatency{
+		BaseMeasurement: dlmf.NewBaseLatency(jobConfig, clientSet, restConfig, dnsLatencyMeasurement, dnsLatencyQuantilesMeasurement, embedCfg),
+	}
+}
+
+func (d *dnsLatency) Start(measurementWg *sync.WaitGroup) error {
+	defer measurementWg.Done()
+	d.startMeasurement([]MeasurementWatcher{})
+	return nil
+}
+
+func (d *dnsLatency) Stop() error {
+	return d.StopMeasurement(d.normalizeMetrics, d.getLatency)
+}
+
+func (d *dnsLatency) Collect(measurementWg *sync.WaitGroup) {
+	defer measurementWg.Done()
+	pods, err := d.ClientSet.CoreV1().Pods(corev1.NamespaceAll).List(context.TODO(), metav1.ListOptions{LabelSelector: "kube-burner-job=dns-latency"})
+	if err != nil {
+		log.Error(err)
+		return
+	}
+	re := regexp.MustCompile(`Average latency:\s+([0-9.]+)\s+ms\s+\(min\s+([0-9.]+),\s+max\s+([0-9.]+)\)`)
+	for _, pod := range pods.Items {
+		req := d.ClientSet.CoreV1().Pods(pod.Namespace).GetLogs(pod.Name, &corev1.PodLogOptions{})
+		stream, err := req.Stream(context.TODO())
+		if err != nil {
+			log.Errorf("error getting logs for %s/%s: %v", pod.Namespace, pod.Name, err)
+			continue
+		}
+		scanner := bufio.NewScanner(stream)
+		var avg, min, max float64
+		for scanner.Scan() {
+			line := scanner.Text()
+			matches := re.FindStringSubmatch(line)
+			if len(matches) == 4 {
+				avg, _ = strconv.ParseFloat(matches[1], 64)
+				min, _ = strconv.ParseFloat(matches[2], 64)
+				max, _ = strconv.ParseFloat(matches[3], 64)
+			}
+		}
+		stream.Close()
+		d.Metrics.Store(string(pod.UID), dnsMetric{
+			Timestamp:  pod.CreationTimestamp.UTC(),
+			Avg:        avg,
+			Min:        min,
+			Max:        max,
+			MetricName: dnsLatencyMeasurement,
+			UUID:       d.Uuid,
+			Namespace:  pod.Namespace,
+			Name:       pod.Name,
+			JobName:    d.JobConfig.Name,
+			Metadata:   d.Metadata,
+		})
+	}
+}
+
+func (d *dnsLatency) normalizeMetrics() float64 {
+	var latencies []float64
+	d.Metrics.Range(func(key, value any) bool {
+		metric := value.(dnsMetric)
+		latencies = append(latencies, metric.Avg)
+		d.NormLatencies = append(d.NormLatencies, metric)
+		return true
+	})
+	if len(latencies) > 0 {
+		summary := metrics.NewLatencySummary(latencies, "DNS")
+		summary.UUID = d.Uuid
+		summary.Timestamp = time.Now().UTC()
+		summary.Metadata = d.Metadata
+		summary.MetricName = dnsLatencyQuantilesMeasurement
+		summary.JobName = d.JobConfig.Name
+		d.LatencyQuantiles = append(d.LatencyQuantiles, summary)
+	}
+	return 0
+}
+
+func (d *dnsLatency) getLatency(metric any) map[string]float64 {
+	m := metric.(dnsMetric)
+	return map[string]float64{"DNS": m.Avg}
+}

--- a/pkg/measurements/factory.go
+++ b/pkg/measurements/factory.go
@@ -61,6 +61,7 @@ var measurementFactoryMap = map[string]NewMeasurementFactory{
 	"netpolLatency":         newNetpolLatencyMeasurementFactory,
 	"dataVolumeLatency":     newDvLatencyMeasurementFactory,
 	"volumeSnapshotLatency": newvolumeSnapshotLatencyMeasurementFactory,
+	"dnsLatency":            newDnsLatencyMeasurementFactory,
 }
 
 func isIndexerOk(configSpec config.Spec, measurement types.Measurement) bool {


### PR DESCRIPTION
## Summary
- add dnsLatency measurement parsing `dnsperf` results
- provide example dns-latency workload and helper script
- document running the DNS latency job and expose doc in MkDocs navigation

## Testing
- `pre-commit run --files mkdocs.yml pkg/measurements/factory.go pkg/measurements/dns_latency.go docs/how-to-dns-latency.md examples/workloads/dns-latency/dns-latency.yml examples/workloads/dns-latency/templates/dnsperf-pod.yml hack/dns-latency.sh`
- `go test ./...`
